### PR TITLE
Make tests pass, by removing `return` from pointy block.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
   - rakudobrew build-panda
   - panda --notests installdeps .
 script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD)'
+  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD.Str)'
   - PERL6LIB=$PWD/blib/lib prove -e perl6 -r t/
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,3 @@ perl6:
 install:
   - rakudobrew build-panda
   - panda --notests installdeps .
-script:
-  - perl6 -MPanda::Builder -e 'Panda::Builder.build($*CWD.Str)'
-  - PERL6LIB=$PWD/blib/lib prove -e perl6 -r t/
-sudo: false

--- a/t/02-p6sgi-simple.t
+++ b/t/02-p6sgi-simple.t
@@ -13,21 +13,21 @@ CATCH { default { $_.say } }
         if my $username = %env<p6sgix.session>.get('username') {
             $body = "TOP: Hello $username";
         }
-        return 200, [], [$body];
+        [200, [], [$body]];
     };
     mount '/login', -> %env {
         %env<p6sgix.session>.set('username', 'foo');
-        return 200, [], ["LOGIN"];
+        [200, [], ["LOGIN"]];
     };
     mount '/counter', -> %env {
         my $counter = %env<p6sgix.session>.get('counter') // 0;
         $counter++;
         %env<p6sgix.session>.set('counter', $counter);
-        return 200,[],["COUNTER=>" ~ $counter];
+        [200,[],["COUNTER=>" ~ $counter]];
     };
     mount '/logout', -> %env {
         %env<p6sgix.session>.expired = True;
-        return 200,[],["LOGOUT"];
+        [200,[],["LOGOUT"]];
     };
 };
 


### PR DESCRIPTION
Hi, I found tests fail with following message:
<details>
<summary>Test report</summary>

```
t/01-basic.t ......... ok

    # Failed test at t/02-p6sgi-simple.t line 38
    # expected: '200'
    #      got: '500'
Attempt to return outside of any Routine
  in block  at t/02-p6sgi-simple.t line 40
  in sub test-psgi at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/sources/B3056D618C3AF5EEA997919542D1D1804F812998 (Crust::Test) line 26
  in sub test-psgi at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/sources/B3056D618C3AF5EEA997919542D1D1804F812998 (Crust::Test) line 19
  in block <unit> at t/02-p6sgi-simple.t line 34

t/02-p6sgi-simple.t ..
Dubious, test returned 1 (wstat 256, 0x100)
No subtests run

Test Summary Report
-------------------
t/02-p6sgi-simple.t (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=2, Tests=4, 12 wallclock secs ( 0.02 usr  0.01 sys + 11.04 cusr  0.90 csys = 11.97 CPU)
Result: FAIL
test stage failed for Crust::Middleware::Session: 0
  in method install at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A (Panda) line 186
  in block  at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A (Panda) line 258
  in method resolve at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A (Panda) line 252
  in sub MAIN at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/resources/E0D978079BB5081DE986D058BB8AB08252F05CC8 line 30
  in block <unit> at /Users/asato/.rakudobrew/moar-blead-nom/install/share/perl6/site/resources/E0D978079BB5081DE986D058BB8AB08252F05CC8 line 165
```

</details>


Accoring to [Perl6 Design Documents](https://design.perl6.org/S06.html#%22Pointy_blocks%22) and [test cases of roast](https://github.com/perl6/roast/blob/master/S04-blocks-and-statements/pointy.t#L72-L89), Using `return` in pointy block causes these exceptions.
So I removed `return` so that these tests will run as expected.