### PR TITLE
Fix failing tests

### DIFF
--- a/t/02-p6sgi-simple.t
+++ b/t/02-p6sgi-simple.t
@@ -3,6 +3,7 @@ use Test;
 use Crust::Builder;
 use Crust::Middleware::Session;
 use Crust::Test;
+use HTTP::Request;
 
 my $store = Crust::Middleware::Session::Store::Memory.new();
 my &app = builder {


### PR DESCRIPTION
Currently compilation of t/02-p6sgi-simple.t fails because of recent rakudo's behavior change around `use`.
I'd like to fix it by adding necessary `use` to the file.
<details>
<summary>output of failing tests</summary>

```
==> Testing Crust::Middleware::Session
t/01-basic.t ......... ok
Could not find symbol '&Request'
  in block  at t/02-p6sgi-simple.t line 37
  in sub test-psgi at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/B3056D618C3AF5EEA997919542D1D1804F812998 (Crust::Test) line 31
  in sub test-psgi at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/B3056D618C3AF5EEA997919542D1D1804F812998 (Crust::Test) line 24
  in block <unit> at t/02-p6sgi-simple.t line 34

Actually thrown at:
  in block  at t/02-p6sgi-simple.t line 37
  in sub test-psgi at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/B3056D618C3AF5EEA997919542D1D1804F812998 (Crust::Test) line 31
  in sub test-psgi at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/B3056D618C3AF5EEA997919542D1D1804F812998 (Crust::Test) line 24
  in block <unit> at t/02-p6sgi-simple.t line 34

t/02-p6sgi-simple.t ..
Dubious, test returned 1 (wstat 256, 0x100)
No subtests run

Test Summary Report
-------------------
t/02-p6sgi-simple.t (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=2, Tests=4,  2 wallclock secs ( 0.02 usr  0.01 sys +  2.37 cusr  0.21 csys =  2.61 CPU)
Result: FAIL
The spawned command 'prove' exited unsuccessfully (exit code: 1)
  in block  at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/24811C576EF8F85E7672B26955C802BB2FC94675 (Panda::Common) line 85
  in sub run-and-gather-output at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/24811C576EF8F85E7672B26955C802BB2FC94675 (Panda::Common) line 71
  in block  at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/48E2EB9144E069353B240AD2D147B48C65F70152 (Panda::Tester) line 29
  in method test at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/48E2EB9144E069353B240AD2D147B48C65F70152 (Panda::Tester) line 16
  in method install at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A (Panda) line 185
  in method resolve at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A (Panda) line 263
  in sub MAIN at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/resources/E0D978079BB5081DE986D058BB8AB08252F05CC8 line 20
  in block <unit> at /Users/asato/.rakudobrew/moar-2017.01/install/share/perl6/site/resources/E0D978079BB5081DE986D058BB8AB08252F05CC8 line 165
```

</details>