### PR TITLE
Fixes the name of a test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp

--- a/t/02-p6sgi-simple.t
+++ b/t/02-p6sgi-simple.t
@@ -32,7 +32,7 @@ CATCH { default { $_.say } }
     };
 };
 
-test-psgi(&app, -> $cb {
+test-p6w(&app, -> $cb {
     my $first-cookie;
     subtest {
         my $res = $cb(HTTP::Request.new(GET => "http://localhost/"));


### PR DESCRIPTION
Changing test-psgi to test-p6w
But still the test fails, returning a 500 error. I can't figure that one out...

Adds .gitignore :see_no_evil: